### PR TITLE
Updated Splunk.Logging.Common dependency version to $ as recommended by ...

### DIFF
--- a/src/Splunk.Logging.SLAB/Splunk.Logging.SLAB.nuspec
+++ b/src/Splunk.Logging.SLAB/Splunk.Logging.SLAB.nuspec
@@ -15,7 +15,7 @@
     <tags>Splunk</tags>
     <language>en-US</language>
     <dependencies>
-          <dependency id="Splunk.Logging.Common" version="1.0" />
+          <dependency id="Splunk.Logging.Common" version="$VERSION$" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Splunk.Logging.TraceListener/Splunk.Logging.TraceListener.nuspec
+++ b/src/Splunk.Logging.TraceListener/Splunk.Logging.TraceListener.nuspec
@@ -15,7 +15,7 @@
     <tags>Splunk</tags>
     <language>en-US</language>
     <dependencies>
-      <dependency id="Splunk.Logging.Common" version="1.0" />
+      <dependency id="Splunk.Logging.Common" version="$VERSION$" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
...@jeffhandley to solve conflict

This change will allow the MyGet versions to match up.