### PR TITLE
TestTcpSocketWriter.TestEventsQueuedWhileWaitingForInitialConnection was false positive

### DIFF
--- a/test/unit-tests/TestTcpSocketWriter.cs
+++ b/test/unit-tests/TestTcpSocketWriter.cs
@@ -84,15 +84,14 @@ namespace Splunk.Logging
         [Fact]
         public async Task TestEventsQueuedWhileWaitingForInitialConnection()
         {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            int port = ((IPEndPoint)listener.Server.LocalEndPoint).Port;
-
+            int port = GetAFreeTcpPort();
+           
             var writer = new TcpSocketWriter(IPAddress.Loopback, port, new ExponentialBackoffTcpReconnectionPolicy(), 100);
 
             writer.Enqueue("Event 1\r\n");
             writer.Enqueue("Event 2\r\n");
 
+            var listener = new TcpListener(IPAddress.Loopback, port);
             listener.Start();
             var listenerClient = listener.AcceptTcpClient();
             var receiverReader = new StreamReader(listenerClient.GetStream());
@@ -103,6 +102,15 @@ namespace Splunk.Logging
             listener.Stop();
             listenerClient.Close();
             writer.Dispose();
+        }
+
+        private static int GetAFreeTcpPort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.Server.LocalEndPoint).Port;
+            listener.Stop();
+            return port;
         }
 
         public class TriggeredTcpReconnectionPolicy : ITcpReconnectionPolicy


### PR DESCRIPTION
If the TcpSocketWriter cannot connect to the server then it blocks the calling thread until it can connect...

According to the unit test TestEventsQueuedWhileWaitingForInitialConnection  that should not happen. But the unit test was a false positive. It opened a listener to extract the port number, but never closed the listener. Thus a listener was available ...