### PR TITLE
Add support for custom event formatter for HTTP Event Collector

### DIFF
--- a/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
+++ b/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
@@ -146,7 +146,7 @@ namespace Splunk.Logging
         /// Logger event info.
         /// </summary>
         [JsonProperty(PropertyName = "event", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public LoggerEvent Event { get; private set; }
+        public dynamic Event { get; set; }
 
         /// <summary>
         /// HttpEventCollectorEventInfo c-or.

--- a/src/Splunk.Logging.Common/HttpEventCollectorSender.cs
+++ b/src/Splunk.Logging.Common/HttpEventCollectorSender.cs
@@ -76,6 +76,12 @@ namespace Splunk.Logging
             string token, List<HttpEventCollectorEventInfo> events, HttpEventCollectorHandler next);
 
         /// <summary>
+        /// Override the default event format.
+        /// </summary>
+        /// <returns>A dynamic type to be serialized.</returns>
+        public delegate dynamic HttpEventCollectorFormatter(HttpEventCollectorEventInfo eventInfo);
+
+        /// <summary>
         /// Recommended default values for events batching
         /// </summary>
         public const int DefaultBatchInterval = 10 * 1000; // 10 seconds
@@ -114,7 +120,7 @@ namespace Splunk.Logging
 
         private HttpClient httpClient = null;
         private HttpEventCollectorMiddleware middleware = null;
-        private Func<HttpEventCollectorEventInfo, dynamic> formatter = null;
+        private HttpEventCollectorFormatter formatter = null;
         // counter for bookkeeping the async tasks 
         private long activeAsyncTasksCount = 0;
 
@@ -142,7 +148,7 @@ namespace Splunk.Logging
             SendMode sendMode,
             int batchInterval, int batchSizeBytes, int batchSizeCount,
             HttpEventCollectorMiddleware middleware,
-            Func<HttpEventCollectorEventInfo, dynamic> formatter = null)
+            HttpEventCollectorFormatter formatter = null)
         {
             this.serializer = new JsonSerializer();
             serializer.NullValueHandling = NullValueHandling.Ignore;

--- a/src/Splunk.Logging.TraceListener/HttpEventCollectorTraceListener.cs
+++ b/src/Splunk.Logging.TraceListener/HttpEventCollectorTraceListener.cs
@@ -100,6 +100,7 @@ namespace Splunk.Logging
     public class HttpEventCollectorTraceListener : TraceListener
     {
         private HttpEventCollectorSender sender;
+        public Func<HttpEventCollectorEventInfo, dynamic> formatter;
 
         /// <summary>
         /// HttpEventCollectorTraceListener c-or.
@@ -122,13 +123,16 @@ namespace Splunk.Logging
             int batchInterval = HttpEventCollectorSender.DefaultBatchInterval,
             int batchSizeBytes = HttpEventCollectorSender.DefaultBatchSize,
             int batchSizeCount = HttpEventCollectorSender.DefaultBatchCount,
-            HttpEventCollectorSender.HttpEventCollectorMiddleware middleware = null)
+            HttpEventCollectorSender.HttpEventCollectorMiddleware middleware = null,
+            Func<HttpEventCollectorEventInfo, dynamic> formatter = null)
         {
+            this.formatter = formatter; // TODO: update the similar section for SLAB
             sender = new HttpEventCollectorSender(
                 uri, token, metadata,
                 sendMode, 
                 batchInterval, batchSizeBytes, batchSizeCount, 
-                middleware);
+                middleware,
+                formatter);
         }
 
         /// <summary>

--- a/src/Splunk.Logging.TraceListener/HttpEventCollectorTraceListener.cs
+++ b/src/Splunk.Logging.TraceListener/HttpEventCollectorTraceListener.cs
@@ -100,7 +100,7 @@ namespace Splunk.Logging
     public class HttpEventCollectorTraceListener : TraceListener
     {
         private HttpEventCollectorSender sender;
-        public Func<HttpEventCollectorEventInfo, dynamic> formatter;
+        public HttpEventCollectorSender.HttpEventCollectorFormatter formatter;
 
         /// <summary>
         /// HttpEventCollectorTraceListener c-or.
@@ -124,7 +124,7 @@ namespace Splunk.Logging
             int batchSizeBytes = HttpEventCollectorSender.DefaultBatchSize,
             int batchSizeCount = HttpEventCollectorSender.DefaultBatchCount,
             HttpEventCollectorSender.HttpEventCollectorMiddleware middleware = null,
-            Func<HttpEventCollectorEventInfo, dynamic> formatter = null)
+            HttpEventCollectorSender.HttpEventCollectorFormatter formatter = null)
         {
             this.formatter = formatter; // TODO: update the similar section for SLAB
             sender = new HttpEventCollectorSender(

--- a/test/unit-tests/TestHttpEventCollector.cs
+++ b/test/unit-tests/TestHttpEventCollector.cs
@@ -112,7 +112,7 @@ namespace Splunk.Logging
 
         private TraceSource TraceCustomFormatter(
             RequestHandler handler,
-            Func<HttpEventCollectorEventInfo, dynamic> formatter,
+            HttpEventCollectorSender.HttpEventCollectorFormatter formatter,
             HttpEventCollectorSender.HttpEventCollectorMiddleware middleware)
         {
             var trace = new TraceSource("HttpEventCollectorLogger");


### PR DESCRIPTION
These changes allow you to to add a `Func<HttpEventCollectorEventInfo, dynamic> formatter` function to a `HttpEventCollectorTraceListener` object.