### PR TITLE
Make Timestamp format invariant to culture.

### DIFF
--- a/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
+++ b/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
@@ -175,7 +175,8 @@ namespace Splunk.Logging
             DateTime datetime, string id, string severity, string message, object data, Metadata metadata)
         {
             double epochTime = (datetime - new DateTime(1970, 1, 1)).TotalSeconds;
-            Timestamp = epochTime.ToString("#.000"); // truncate to 3 digits after floating point
+            // truncate to 3 digits after floating point
+            Timestamp = epochTime.ToString("#.000", System.Globalization.CultureInfo.InvariantCulture);
             this.metadata = metadata ?? new Metadata();
             Event = new LoggerEvent(id, severity, message, data);
         }


### PR DESCRIPTION
See https://github.com/splunk/splunk-library-dotnetlogging/issues/19