### PR TITLE
Added an override for TraceData method with object data parameter

### DIFF
--- a/src/Splunk.Logging.TraceListener/HttpEventCollectorTraceListener.cs
+++ b/src/Splunk.Logging.TraceListener/HttpEventCollectorTraceListener.cs
@@ -184,6 +184,15 @@ namespace Splunk.Logging
             sender.Send(message: message);
         }
 
+        public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id, object data)
+        {
+            sender.Send(
+                id: id.ToString(),
+                severity: eventType.ToString(),
+                data: data
+            );
+        }
+
         public override void TraceData(
             TraceEventCache eventCache, 
             string source, 

--- a/test/unit-tests/TestHttpEventCollector.cs
+++ b/test/unit-tests/TestHttpEventCollector.cs
@@ -234,6 +234,17 @@ namespace Splunk.Logging
 
             trace = Trace((token, events) =>
             {
+                Assert.True(events[0].Event.Severity == "Information");
+                Assert.True(events[0].Event.Id == "1");
+                Assert.True(events[0].Event.Data.MyInfo == "one");
+                Assert.True(events[0].Event.Data.OtherInfo == "two");
+                return new Response();
+            });
+            trace.TraceData(TraceEventType.Information, 1, new { MyInfo = "one", OtherInfo = "two" });
+            trace.Close();
+
+            trace = Trace((token, events) =>
+            {
                 Assert.True(events[0].Event.Severity == "Critical");
                 Assert.True(events[0].Event.Id == "2");
                 return new Response();


### PR DESCRIPTION
Included the "TraceData" implementation method on HttpEventCollectorTraceListener.

`public virtual void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id, object data);`