### PR TITLE
Fix timestamp format for all locales

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,14 @@ image:
 init:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
-# Build 6.2 and 6.3
+# Test against two most recent major versions, see: https://www.splunk.com/page/previous_releases#x86_64windows
 environment:
   matrix:
-  - SPLUNK_VERSION: 7.0.1
-    SPLUNK_BUILD: 2b5b15c4ee89
+  - SPLUNK_VERSION: 8.0.2
+    SPLUNK_BUILD: a7f645ddaf91
     SDK_APP_VERSION: 1.0.0
-  - SPLUNK_VERSION: 7.2.0
-    SPLUNK_BUILD: 8c86330ac18
+  - SPLUNK_VERSION: 7.3.4
+    SPLUNK_BUILD: 13e97039fb65
     SDK_APP_VERSION: 1.0.0
 
   VisualStudioVersion: 15.0

--- a/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
+++ b/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
@@ -175,8 +175,8 @@ namespace Splunk.Logging
             DateTime datetime, string id, string severity, string message, object data, Metadata metadata)
         {
             double epochTime = (datetime - new DateTime(1970, 1, 1)).TotalSeconds;
-            // truncate to 3 digits after floating point using "F3" format for InvariantCulture support
-            Timestamp = epochTime.ToString("F3", System.Globalization.CultureInfo.InvariantCulture);
+            // truncate to 3 digits after floating point
+            Timestamp = epochTime.ToString("#.000", System.Globalization.CultureInfo.InvariantCulture);
             this.metadata = metadata ?? new Metadata();
             Event = new LoggerEvent(id, severity, message, data);
         }

--- a/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
+++ b/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
@@ -175,8 +175,8 @@ namespace Splunk.Logging
             DateTime datetime, string id, string severity, string message, object data, Metadata metadata)
         {
             double epochTime = (datetime - new DateTime(1970, 1, 1)).TotalSeconds;
-            // truncate to 3 digits after floating point
-            Timestamp = epochTime.ToString("#.000", System.Globalization.CultureInfo.InvariantCulture);
+            // truncate to 3 digits after floating point using "F3" format for InvariantCulture support
+            Timestamp = epochTime.ToString("F3", System.Globalization.CultureInfo.InvariantCulture);
             this.metadata = metadata ?? new Metadata();
             Event = new LoggerEvent(id, severity, message, data);
         }

--- a/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
+++ b/src/Splunk.Logging.Common/HttpEventCollectorEventInfo.cs
@@ -176,7 +176,7 @@ namespace Splunk.Logging
         {
             double epochTime = (datetime - new DateTime(1970, 1, 1)).TotalSeconds;
             // truncate to 3 digits after floating point
-            Timestamp = epochTime.ToString("#.000", Thread.CurrentThread.CurrentCulture);
+            Timestamp = epochTime.ToString("#.000", System.Globalization.CultureInfo.InvariantCulture);
             this.metadata = metadata ?? new Metadata();
             Event = new LoggerEvent(id, severity, message, data);
         }

--- a/test/unit-tests/TestHttpEventCollector.cs
+++ b/test/unit-tests/TestHttpEventCollector.cs
@@ -718,17 +718,23 @@ namespace Splunk.Logging
             Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
 
             // test setting timestamp
-            DateTime utcNow = DateTime.UtcNow;
-            double nowEpoch = (utcNow - new DateTime(1970, 1, 1)).TotalSeconds;
-            
-            HttpEventCollectorEventInfo ei =
-                new HttpEventCollectorEventInfo(utcNow.AddHours(-1), null, null, null, null, null);
+            DateTime utcTime = new DateTime(2020, 1, 1);
+            double epochTime = (utcTime - new DateTime(1970, 1, 1)).TotalSeconds;
+
+            HttpEventCollectorEventInfo eiDE =
+                new HttpEventCollectorEventInfo(utcTime.AddHours(-1), null, null, null, null, null);
+
+            // Make sure this format matches expected comma format with three decimal places
+            Assert.Equal(eiDE.Timestamp, "00,000");
 
             // Reset the culture before any assertions
             Thread.CurrentThread.CurrentCulture = backupCulture;
 
-            // Ensure we have a comma when using a non-US culture
-            Assert.True(ei.Timestamp.Contains(","), "Timestamp did not contain a comma: " + ei.Timestamp);
+            HttpEventCollectorEventInfo eiUS =
+                new HttpEventCollectorEventInfo(utcTime.AddHours(-1), null, null, null, null, null);
+
+            // Make sure this format matches expected decimal point format with three decimal places
+            Assert.Equal(eiUS, "00.000");
         }
 
         

--- a/test/unit-tests/TestHttpEventCollector.cs
+++ b/test/unit-tests/TestHttpEventCollector.cs
@@ -728,7 +728,7 @@ namespace Splunk.Logging
             Thread.CurrentThread.CurrentCulture = backupCulture;
 
             // Ensure we have a comma when using a non-US culture
-            Assert.True(ei.Timestamp.Contains(","));
+            Assert.True(ei.Timestamp.Contains(","), "Timestamp did not contain a comma: " + ei.Timestamp);
         }
 
         

--- a/test/unit-tests/TestHttpEventCollector.cs
+++ b/test/unit-tests/TestHttpEventCollector.cs
@@ -734,7 +734,7 @@ namespace Splunk.Logging
                 new HttpEventCollectorEventInfo(utcTime.AddHours(-1), null, null, null, null, null);
 
             // Make sure this format matches expected decimal point format with three decimal places
-            Assert.Equal(eiUS, "00.000");
+            Assert.Equal(eiUS.Timestamp, "00.000");
         }
 
         

--- a/test/unit-tests/TestHttpEventCollector.cs
+++ b/test/unit-tests/TestHttpEventCollector.cs
@@ -718,23 +718,22 @@ namespace Splunk.Logging
             Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
 
             // test setting timestamp
-            DateTime utcTime = new DateTime(2020, 1, 1);
-            double epochTime = (utcTime - new DateTime(1970, 1, 1)).TotalSeconds;
+            DateTime fixedTime = new DateTime(2020, 1, 1);
 
             HttpEventCollectorEventInfo eiDE =
-                new HttpEventCollectorEventInfo(utcTime.AddHours(-1), null, null, null, null, null);
+                new HttpEventCollectorEventInfo(fixedTime.AddHours(-1), null, null, null, null, null);
 
-            // Make sure this format matches expected comma format with three decimal places
-            Assert.Equal(eiDE.Timestamp, "00,000");
+            // Make sure this format matches expected decimal format with three decimal places
+            Assert.Equal(eiDE.Timestamp, "1577833200.000");
 
             // Reset the culture before any assertions
             Thread.CurrentThread.CurrentCulture = backupCulture;
 
             HttpEventCollectorEventInfo eiUS =
-                new HttpEventCollectorEventInfo(utcTime.AddHours(-1), null, null, null, null, null);
+                new HttpEventCollectorEventInfo(fixedTime.AddHours(-1), null, null, null, null, null);
 
-            // Make sure this format matches expected decimal point format with three decimal places
-            Assert.Equal(eiUS.Timestamp, "00.000");
+            // Make sure this format matches expected decimal format with three decimal places
+            Assert.Equal(eiUS.Timestamp, "1577833200.000");
         }
 
         


### PR DESCRIPTION
Resolve #55.

Fix timestamp format to use decimal points for all locales to be compatible with Splunk expected format.

Fix tests to ensure decimals being used for DE and US. DE and SE were previously failing due to the use of commas per issue #19. This was originally fixed in https://github.com/splunk/splunk-library-dotnetlogging/pull/20 but regression was introduced while adding tests.

Update testing matrix to target Splunk 8.0.2 and 7.3.4.

